### PR TITLE
feat: WIP discover lib types from source files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graft",
-  "version": "2.0.0-0",
+  "version": "3.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -932,16 +932,30 @@
       }
     },
     "@ts-morph/common": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.7.1.tgz",
-      "integrity": "sha512-1C6sPSJQdCrpX2S1CcckmD4sv1SDOn8uLaQeStVP7Z5qr8xv+JgAdI2Kta+EYBAIKsLrfkJR2iabZ8+43vWO4A==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.8.1.tgz",
+      "integrity": "sha512-3TC91LfCKCNCW7zYpegoMnMa9VigXtZHQererUM9pCvZKN3ust3ioLA0kfX+UHSzIGln+UYYiRzfOsv0QoiUng==",
       "requires": {
         "@dsherret/to-absolute-glob": "^2.0.2",
-        "fast-glob": "^3.2.4",
+        "fast-glob": "^3.2.5",
         "is-negated-glob": "^1.0.0",
         "mkdirp": "^1.0.4",
-        "multimatch": "^5.0.0",
-        "typescript": "~4.1.2"
+        "multimatch": "^5.0.0"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        }
       }
     },
     "@tsconfig/node12": {
@@ -2688,6 +2702,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
       "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -5739,6 +5754,21 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
+    "resolve-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -6582,12 +6612,12 @@
       }
     },
     "ts-morph": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-9.1.0.tgz",
-      "integrity": "sha512-sei4u651MBenr27sD6qLDXN3gZ4thiX71E3qV7SuVtDas0uvK2LtgZkIYUf9DKm/fLJ6AB/+yhRJ1vpEBJgy7Q==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-10.0.1.tgz",
+      "integrity": "sha512-T1zufImtp5goTLTFhzi7XuKR1y/f+Jwz1gSULzB045LFjXuoqVlR87sfkpyWow8u2JwgusCJrhOnwmHCFNutTQ==",
       "requires": {
         "@dsherret/to-absolute-glob": "^2.0.2",
-        "@ts-morph/common": "~0.7.0",
+        "@ts-morph/common": "~0.8.0",
         "code-block-writer": "^10.1.1"
       }
     },
@@ -6653,7 +6683,8 @@
     "typescript": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ=="
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graft",
-  "version": "1.0.1",
+  "version": "2.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graft",
-  "version": "3.0.0-1",
+  "version": "2.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -950,11 +950,6 @@
       "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==",
       "dev": true
     },
-    "@tsconfig/node14": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.0.tgz",
-      "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ=="
-    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graft",
-  "version": "1.0.1",
+  "version": "2.0.0-0",
   "description": "Graft TypeScript type definitions from declaration files to local modules",
   "bin": "bin/ts-graft.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-graft",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "Graft TypeScript type definitions from declaration files to local modules",
   "bin": "bin/ts-graft.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "cosmiconfig": "^7.0.0",
     "read-pkg-up": "^7.0.1",
     "resolve-cwd": "^3.0.0",
-    "ts-morph": "^9.1.0",
+    "resolve-pkg": "^2.0.0",
+    "ts-morph": "^10.0.1",
     "zod": "^1.11.10"
   },
   "devDependencies": {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -38,6 +38,7 @@ describe("graft", () => {
       .spyOn(graft, "graftFile")
       .mockImplementation(async (params) => {
         expect(params.project).toBe(project);
+        // TODO: this pollutes file system
         return params.project.createSourceFile("foo", undefined, {
           overwrite: true,
         });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
-import graft, { config } from "./index";
+import graft, { config, graftLibDefinitions } from "./index";
 
 export async function run(): Promise<void> {
-  await graft.graft({ config: await config.load() });
+  // await graft.graft({ config: await config.load() });
+  graftLibDefinitions({ config: await config.load() });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { basename, dirname, sep as pathSep } from "path";
 import readPkgUp from "read-pkg-up";
 import resolveCwd from "resolve-cwd";
+import resolvePkg from "resolve-pkg";
 import {
   InterfaceDeclaration,
   Node,
@@ -13,7 +14,6 @@ import {
   ScriptTarget,
   ExportableNode,
 } from "ts-morph";
-import { nodeModuleNameResolver } from "typescript";
 import { Config } from "./config";
 export * as config from "./config";
 
@@ -141,6 +141,7 @@ export function graftLibDefinitions(params: GraftParams) {
       compilerOptions: {
         target: ScriptTarget.ES2015,
       },
+      libFolderPath: resolvePkg("typescript/lib"),
     });
   for (const graft of params.config.grafts) {
     const sourceFile = project.addSourceFileAtPath(graft.source);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { dirname } from "path";
+import { basename, dirname, sep as pathSep } from "path";
 import readPkgUp from "read-pkg-up";
 import resolveCwd from "resolve-cwd";
 import {
@@ -9,7 +9,11 @@ import {
   SyntaxKind,
   TypeAliasDeclaration,
   SourceFile,
+  Identifier,
+  ScriptTarget,
+  ExportableNode,
 } from "ts-morph";
+import { nodeModuleNameResolver } from "typescript";
 import { Config } from "./config";
 export * as config from "./config";
 
@@ -129,3 +133,125 @@ export default {
     output.addTypeAliases(resolvedStructures.filter(Structure.isTypeAlias));
   },
 };
+
+export function graftLibDefinitions(params: GraftParams) {
+  const project =
+    params.project ??
+    new Project({
+      compilerOptions: {
+        target: ScriptTarget.ES2015,
+      },
+    });
+  for (const graft of params.config.grafts) {
+    const sourceFile = project.addSourceFileAtPath(graft.source);
+    const outputFile = project.createSourceFile(graft.output, undefined, {
+      overwrite: true,
+    });
+    const libDefinitionNodes = gatherLibDefinitions(
+      gatherIdentifiers(sourceFile),
+      new Set(graft.include)
+    );
+    for (const node of libDefinitionNodes) {
+      const newNode = transposeDeclaration(outputFile, node);
+      if (newNode) newNode.setIsExported(true);
+    }
+    outputFile.saveSync();
+  }
+}
+
+export function transposeDeclaration(
+  outputFile: SourceFile,
+  node: Node
+): ExportableNode | undefined {
+  if (Node.isVariableDeclaration(node)) {
+    return outputFile.addVariableStatement(
+      node.getVariableStatement()!.getStructure()
+    );
+  } else if (Node.isInterfaceDeclaration(node)) {
+    return outputFile.addInterface(node.getStructure());
+  } else if (Node.isClassDeclaration(node)) {
+    return outputFile.addClass(node.getStructure());
+  } else if (Node.isTypeAliasDeclaration(node)) {
+    return outputFile.addTypeAlias(node.getStructure());
+  } else if (Node.isFunctionDeclaration(node)) {
+    const structure = node.getStructure();
+    if (Structure.isFunction(structure)) {
+      return outputFile.addFunction(structure);
+    }
+  }
+}
+
+export function gatherLibDefinitions(
+  identifiers: Identifier[],
+  includeLibs: Set<string> = new Set()
+): Node[] {
+  const result: Node[] = [];
+  const rm: Map<Node, Node[]> = new Map();
+  const urm: Map<Node, Node[]> = new Map();
+  const resolved: Set<Node> = new Set();
+  const unresolved: Set<Node> = new Set();
+  function enqueue(ids: Identifier[], path: Node[]) {
+    ids
+      .flatMap((id) => id.getDefinitionNodes())
+      .forEach((n) => {
+        if (resolved.has(n)) return;
+        if (path.length === 0) {
+          unresolved.add(n);
+          urm.set(n, path);
+        } else {
+          // only include abstract types of indirect identifiers
+          switch (n.getKind()) {
+            case SyntaxKind.InterfaceDeclaration:
+            case SyntaxKind.TypeAliasDeclaration:
+              unresolved.add(n);
+              urm.set(n, path);
+              break;
+          }
+        }
+      });
+  }
+  enqueue(identifiers, []);
+  while (unresolved.size > 0) {
+    for (const [node, path] of urm.entries()) {
+      unresolved.delete(node);
+      urm.delete(node);
+      resolved.add(node);
+      rm.set(node, path);
+
+      const lib = tsLibName(node);
+      if (lib && (includeLibs.size === 0 || includeLibs.has(lib))) {
+        result.push(node);
+      }
+
+      enqueue(gatherIdentifiers(node), [...path, node]);
+    }
+  }
+
+  return result;
+}
+
+export function gatherIdentifiers(node: Node): Identifier[] {
+  return node.getDescendantsOfKind(SyntaxKind.Identifier);
+}
+
+export function gatherNodes(
+  node: Node,
+  predicate: (node: Node) => boolean
+): Node[] {
+  const result: Node[] = [];
+  node.forEachDescendant((n) => {
+    if (predicate(n)) {
+      result.push(n);
+    }
+  });
+  return result;
+}
+
+export function tsLibName(node: Node): string | undefined {
+  const filePath = node.getSourceFile().getFilePath();
+  const pathParts = filePath.split(pathSep);
+  const [grandParent, parent, file] = pathParts.slice(-3);
+  if (grandParent === "typescript" && parent === "lib") {
+    return basename(file, ".d.ts").match(/^lib\.(?<lib>.*)$/)?.groups?.lib;
+  }
+}


### PR DESCRIPTION
This PR would change how ts-graft works...

Old way:
- provide a definition file and list of types to be grafted.
- only interface and type aliases are grafted

New way:
- provide a source file and list of TS libs from which type definitions are grafted
- function, variable and class declarations **directly** referenced by the source file are also grafted

Issues to consider:

- The source file has to be changed to use the grafted lib
  - This means running ts-graft is not idempotent
  - Maybe resolved by updating the graft file instead of overwriting it, though this wouldn't help if the grafted definitions are out of date with the current typescript version

